### PR TITLE
fix: overflow in images is fixed

### DIFF
--- a/src/components/events/editor/mdEditor.tsx
+++ b/src/components/events/editor/mdEditor.tsx
@@ -69,7 +69,7 @@ export function MarkdownEditor({
       Highlight,
       Image.configure({
         HTMLAttributes: {
-          style: 'max-width: 500px;'
+          style: 'width: 100%; max-width: 500px;'
         }
       }),
       Youtube.configure({


### PR DESCRIPTION
issue: 
in MarkdownEditor , if the image is bigger than the viewport, then overflow happens